### PR TITLE
add panel_borders argument to theme_grattan()

### DIFF
--- a/R/theme_grattan.R
+++ b/R/theme_grattan.R
@@ -11,6 +11,7 @@
 #' to go in a Grattan report box.
 #' @param legend "off" by default. Set to "bottom", "left", "right" or "top" as
 #' desired, or a two element numeric vector such as c(0.9, 0.1).
+#' @param panel_borders `FALSE` by default. Set to `TRUE` to enable a black border around the plotting area.
 #'
 #' @importFrom ggthemes theme_foundation
 #' @import ggrepel
@@ -112,7 +113,8 @@ theme_grattan <- function(base_size = 18,
                            base_family = "sans",
                            flipped = FALSE,
                            background = "white",
-                           legend = "none") {
+                           legend = "none",
+                           panel_borders = FALSE) {
 
   ret <-
     ggthemes::theme_foundation(base_size = base_size, base_family = base_family) +
@@ -182,12 +184,20 @@ theme_grattan <- function(base_size = 18,
           plot.margin = unit(c(0.5, 0.6, 0.1, 0.01) , "lines"),
           complete = TRUE)
 
+  # add panel borders if the use requests them
+
+  if(panel_borders) {
+    ret <- ret +
+      theme(panel.background = element_rect(linetype = 1,
+                                            colour = "black"))
+  }
+
 
   # call a function that modifies various geom defaults
   grattanify_geom_defaults()
 
   # reverse when flipped = TRUE
-  if (flipped == TRUE) {
+  if (flipped) {
     ret <- ret + ggplot2::theme(panel.grid.major.x = ggplot2::element_line(),
                        panel.grid.major.y = ggplot2::element_blank(),
                        axis.line.x = ggplot2::element_blank(),

--- a/man/theme_grattan.Rd
+++ b/man/theme_grattan.Rd
@@ -5,7 +5,7 @@
 \title{Create a ggplot2 theme consistent with the Grattan style guide.}
 \usage{
 theme_grattan(base_size = 18, base_family = "sans", flipped = FALSE,
-  background = "white", legend = "none")
+  background = "white", legend = "none", panel_borders = FALSE)
 }
 \arguments{
 \item{base_size}{Size for text elements. Defaults to 18, as per the Grattan
@@ -23,6 +23,8 @@ to go in a Grattan report box.}
 
 \item{legend}{"off" by default. Set to "bottom", "left", "right" or "top" as
 desired, or a two element numeric vector such as c(0.9, 0.1).}
+
+\item{panel_borders}{`FALSE` by default. Set to `TRUE` to enable a black border around the plotting area.}
 }
 \description{
 Create a ggplot2 theme consistent with the Grattan style guide.

--- a/tests/figs/vdiffr-tests/border-plot.svg
+++ b/tests/figs/vdiffr-tests/border-plot.svg
@@ -1,0 +1,172 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA=='>
+    <rect x='28.24' y='92.34' width='225.31' height='413.52' />
+  </clipPath>
+</defs>
+<rect x='28.24' y='92.34' width='225.31' height='413.52' style='stroke-width: 1.75; fill: #FFFFFF;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<polyline points='28.24,493.46 253.55,493.46 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<polyline points='28.24,413.48 253.55,413.48 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<polyline points='28.24,333.49 253.55,333.49 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<polyline points='28.24,253.51 253.55,253.51 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<polyline points='28.24,173.52 253.55,173.52 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<polyline points='28.24,93.54 253.55,93.54 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='80.75' cy='288.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='126.31' cy='263.11' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='124.22' cy='288.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='74.46' cy='135.13' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='43.83' cy='167.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='55.35' cy='111.13' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='88.34' cy='309.50' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='60.59' cy='216.71' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='71.32' cy='237.51' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='38.49' cy='167.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<circle cx='104.84' cy='311.10' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8MjUzLjU1fDUwNS44Nnw5Mi4zNA==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ='>
+    <rect x='257.15' y='92.34' width='225.31' height='413.52' />
+  </clipPath>
+</defs>
+<rect x='257.15' y='92.34' width='225.31' height='413.52' style='stroke-width: 1.75; fill: #FFFFFF;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='257.15,493.46 482.45,493.46 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='257.15,413.48 482.45,413.48 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='257.15,333.49 482.45,333.49 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='257.15,253.51 482.45,253.51 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='257.15,173.52 482.45,173.52 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='257.15,93.54 482.45,93.54 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='325.37' cy='317.50' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='338.72' cy='317.50' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='356.53' cy='311.10' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='369.36' cy='363.89' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='368.31' cy='346.29' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='368.31' cy='368.69' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='333.22' cy='338.29' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw1MDUuODZ8OTIuMzQ=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ='>
+    <rect x='486.05' y='92.34' width='225.31' height='413.52' />
+  </clipPath>
+</defs>
+<rect x='486.05' y='92.34' width='225.31' height='413.52' style='stroke-width: 1.75; fill: #FFFFFF;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='486.05,493.46 711.36,493.46 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='486.05,413.48 711.36,413.48 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='486.05,333.49 711.36,333.49 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='486.05,253.51 711.36,253.51 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='486.05,173.52 711.36,173.52 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<polyline points='486.05,93.54 711.36,93.54 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='597.21' cy='354.29' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='604.02' cy='424.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='630.21' cy='391.08' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='612.40' cy='376.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='615.02' cy='410.28' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='692.01' cy='487.06' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='701.12' cy='487.06' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='696.98' cy='418.28' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='601.40' cy='405.48' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='596.95' cy='410.28' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='618.16' cy='440.67' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='618.43' cy='346.29' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='583.07' cy='400.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<circle cx='604.02' cy='413.48' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw1MDUuODZ8OTIuMzQ=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjguMjR8MjUzLjU1fDkyLjM0fDYxLjg3'>
+    <rect x='28.24' y='61.87' width='225.31' height='30.47' />
+  </clipPath>
+</defs>
+<rect x='28.24' y='61.87' width='225.31' height='30.47' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjguMjR8MjUzLjU1fDkyLjM0fDYxLjg3)' />
+<g clip-path='url(#cpMjguMjR8MjUzLjU1fDkyLjM0fDYxLjg3)'><text x='135.89' y='83.30' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjU3LjE1fDQ4Mi40NXw5Mi4zNHw2MS44Nw=='>
+    <rect x='257.15' y='61.87' width='225.31' height='30.47' />
+  </clipPath>
+</defs>
+<rect x='257.15' y='61.87' width='225.31' height='30.47' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw5Mi4zNHw2MS44Nw==)' />
+<g clip-path='url(#cpMjU3LjE1fDQ4Mi40NXw5Mi4zNHw2MS44Nw==)'><text x='364.79' y='83.30' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>6</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDg2LjA1fDcxMS4zNnw5Mi4zNHw2MS44Nw=='>
+    <rect x='486.05' y='61.87' width='225.31' height='30.47' />
+  </clipPath>
+</defs>
+<rect x='486.05' y='61.87' width='225.31' height='30.47' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNDg2LjA1fDcxMS4zNnw5Mi4zNHw2MS44Nw==)' />
+<g clip-path='url(#cpNDg2LjA1fDcxMS4zNnw5Mi4zNHw2MS44Nw==)'><text x='593.70' y='83.30' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>8</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='28.24,505.86 253.55,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='63.99,510.34 63.99,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='116.36,510.34 116.36,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='168.73,510.34 168.73,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='221.10,510.34 221.10,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.98' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='111.35' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='163.72' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='216.10' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<polyline points='257.15,505.86 482.45,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='292.90,510.34 292.90,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='345.27,510.34 345.27,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='397.64,510.34 397.64,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='450.01,510.34 450.01,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='287.89' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='340.26' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='392.63' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='445.00' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<polyline points='486.05,505.86 711.36,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='521.80,510.34 521.80,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='574.17,510.34 574.17,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='626.54,510.34 626.54,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='678.91,510.34 678.91,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='516.79' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='569.16' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='621.53' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='673.91' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='499.66' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='419.67' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='339.69' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='259.70' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='179.72' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='99.73' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>35</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='360.80' y='546.93' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='18.00px' lengthAdjust='spacingAndGlyphs'>wt</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='44.68' style='font-size: 18.00px; fill: #6A737B; font-family: Liberation Sans;' textLength='682.61px' lengthAdjust='spacingAndGlyphs'>Either put units here or jam an elaborate thing here that describes both axes, whatevs</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='19.59' style='font-size: 18.00px; font-weight: bold; fill: #6A737B; font-family: Liberation Sans;' textLength='638.33px' lengthAdjust='spacingAndGlyphs'>Here goes a Grattan title, blah blah lots of words go here extremely orange</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='572.48' style='font-size: 9.99px; font-style: italic; font-family: Liberation Sans;' textLength='143.16px' lengthAdjust='spacingAndGlyphs'>Notes: Blah Source: somewhere</text></g>
+</svg>

--- a/tests/figs/vdiffr-tests/coloured-plot.svg
+++ b/tests/figs/vdiffr-tests/coloured-plot.svg
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw=='>
+    <rect x='28.24' y='61.87' width='683.12' height='443.99' />
+  </clipPath>
+</defs>
+<rect x='28.24' y='61.87' width='683.12' height='443.99' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,492.55 711.36,492.55 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,406.67 711.36,406.67 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,320.79 711.36,320.79 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,234.91 711.36,234.91 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,149.03 711.36,149.03 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,63.15 711.36,63.15 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='235.07' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='275.56' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='187.44' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='329.55' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='343.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='368.45' cy='353.42' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='385.92' cy='418.69' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='325.58' cy='245.22' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='319.23' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='358.58' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='465.31' cy='382.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='411.33' cy='367.17' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='419.26' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='652.68' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='680.31' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='667.77' cy='411.82' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='168.38' cy='107.81' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='75.49' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='110.42' cy='82.05' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='210.46' cy='295.03' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='377.98' cy='398.08' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='364.48' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='428.79' cy='435.87' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='429.59' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='126.30' cy='195.41' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='158.85' cy='217.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='59.30' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='322.40' cy='392.93' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='258.89' cy='325.94' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='385.92' cy='406.67' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='260.48' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='235.07' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='275.56' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='187.44' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='329.55' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='343.12' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='368.45' cy='353.42' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='385.92' cy='418.69' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='325.58' cy='245.22' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='319.23' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='358.58' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='465.31' cy='382.62' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='411.33' cy='367.17' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='419.26' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='652.68' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='680.31' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='667.77' cy='411.82' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='168.38' cy='107.81' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='75.49' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='110.42' cy='82.05' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='210.46' cy='295.03' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='377.98' cy='398.08' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='364.48' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='428.79' cy='435.87' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='429.59' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='126.30' cy='195.41' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='158.85' cy='217.74' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='59.30' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='322.40' cy='392.93' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='258.89' cy='325.94' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='385.92' cy='406.67' r='2.60pt' style='stroke-width: 0.71; stroke: #D4582A; fill: #D4582A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='260.48' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #FFC35A; fill: #FFC35A;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='498.74' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='412.87' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='326.99' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='241.11' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='155.23' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='69.35' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>35</text></g>
+<polyline points='28.24,505.86 711.36,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='136.62,510.34 136.62,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='295.41,510.34 295.41,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='454.20,510.34 454.20,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='612.98,510.34 612.98,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='131.62' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='290.40' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='449.19' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='607.98' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='360.80' y='546.93' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='18.00px' lengthAdjust='spacingAndGlyphs'>wt</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='44.68' style='font-size: 18.00px; fill: #6A737B; font-family: Liberation Sans;' textLength='682.61px' lengthAdjust='spacingAndGlyphs'>Either put units here or jam an elaborate thing here that describes both axes, whatevs</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='19.59' style='font-size: 18.00px; font-weight: bold; fill: #6A737B; font-family: Liberation Sans;' textLength='638.33px' lengthAdjust='spacingAndGlyphs'>Here goes a Grattan title, blah blah lots of words go here extremely orange</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='572.48' style='font-size: 9.99px; font-style: italic; font-family: Liberation Sans;' textLength='143.16px' lengthAdjust='spacingAndGlyphs'>Notes: Blah Source: somewhere</text></g>
+</svg>

--- a/tests/testthat/test-with-vdiffr.R
+++ b/tests/testthat/test-with-vdiffr.R
@@ -1,20 +1,44 @@
 
 context("vdiffr-tests")
 
-normal_plot <- mtcars %>%
+base_plot <- mtcars %>%
   ggplot(aes(x = wt,
              y = mpg)) +
   geom_point() +
-  grattantheme::theme_grattan() +
   labs(title = "Here goes a Grattan title, blah blah lots of words go here extremely orange",
        subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs",
        caption = "Notes: Blah Source: somewhere")
+
+normal_plot <- base_plot +
+  theme_grattan()
+
+border_plot <- base_plot +
+  facet_wrap(~cyl) +
+  theme_grattan(panel_borders = TRUE)
+
+coloured_plot <- base_plot +
+  geom_point(aes(col = factor(cyl))) +
+  grattan_colour_manual(n = 3) +
+  theme_grattan()
 
 test_that("normal plot looks correct", {
 
   vdiffr::expect_doppelganger("normal plot", normal_plot)
 
 })
+
+test_that("faceted plot with borders looks correct", {
+
+  vdiffr::expect_doppelganger("border plot", border_plot)
+
+})
+
+test_that("plot with discrete colours looks correct", {
+
+  vdiffr::expect_doppelganger("coloured plot", coloured_plot)
+
+})
+
 
 # test_that("fullslide plot looks correct", {
 #


### PR DESCRIPTION
`theme_grattan()` gains a new `panel_borders` argument, FALSE by default. Setting it to TRUE enables (thin, black) borders around each panel. 

Example: 
mtcars %>%
  ggplot(aes(x = wt,
             y = mpg)) +
  geom_point() +
  facet_wrap(~cyl) +
  theme_grattan(panel_borders = TRUE)

![test](https://user-images.githubusercontent.com/8002951/62335607-bce87a80-b50f-11e9-860c-d00926529ef6.png)
