### PR TITLE
vertically expand plot to fill whitespace when subtitle is absent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable --yes
   #- sudo apt-get --yes --force-yes update -qq
-  - sudo apt-get install --yes libudunits2-dev libproj-dev libgeos-dev libgdal-dev
-  - Rscript -e 'update.packages(ask = FALSE)'
+  #- sudo apt-get install --yes libudunits2-dev libproj-dev libgeos-dev libgdal-dev
+  #- Rscript -e 'update.packages(ask = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: grattantheme
 Type: Package
 Title: Create Graphs in the Grattan Institute Style
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person("Matt", "Cowgill", email = "matthew.cowgill@grattaninstitute.edu.au", 
                 role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# grattantheme 0.5.1
+* Charts without a subtitle that are saved as "fullslide" or similar will now vertically expand the plot to fill the space of the absent subtitle 
+
 # grattantheme 0.5.0
 * grattan_anim_save() allows users to save gganimate animations formatted in the Grattan style
 * theme_grattan() gains a panel_borders argument

--- a/R/create_fullslide.R
+++ b/R/create_fullslide.R
@@ -10,10 +10,6 @@ create_fullslide <- function(object,
                              warn_labs = TRUE,
                              print_object = TRUE) {
 
-  # if(!"gg" %in% class(object)) {
-  #   stop("type = 'fullslide' only works with ggplot graph objects")
-  # }
-
   if(missing(type)) {
     stop("You must specify a plot type.")
   }
@@ -41,10 +37,11 @@ create_fullslide <- function(object,
     stored_title <- ""
   }
 
-  if(stored_subtitle == "\n "){
+  if(is.null(stored_subtitle) | stored_subtitle == "") {
     if(warn_labs) {
       message(paste0("Your plot has no subtitle, which is weird for type = ", type, "\nConsider adding a subtitle using labs(subtitle = 'Text')"))
     }
+
     stored_subtitle <- NULL
   }
 
@@ -58,6 +55,10 @@ create_fullslide <- function(object,
   # remove title and subtitle on chart
   p$labels$title <- NULL
   p$labels$subtitle <- NULL
+
+  # how many lines in the subtitle?
+
+  subtitle_lines <- ceiling(nchar(stored_subtitle) / chart_types$subtitle[chart_types$type == type])
 
   # convert to gtable
   p_built$plot <- p
@@ -104,7 +105,8 @@ create_fullslide <- function(object,
   top_border_height <- ifelse(type == "blog", blog_border, 0.70)
   header_height <- 1.75
   linegrob_height <- 0.1
-  subtitle_height <- ifelse(is.null(stored_subtitle), 0.21, 1.76)
+  subtitle_height <- ifelse(is.null(stored_subtitle), 0.21,
+                            ifelse(subtitle_lines == 1, 1.76 / 2, 1.76))
   bottom_border_height <- ifelse(type == "blog", blog_border, 0.24)
 
   non_plot_height <- sum(top_border_height, header_height, linegrob_height,

--- a/R/create_fullslide.R
+++ b/R/create_fullslide.R
@@ -43,9 +43,9 @@ create_fullslide <- function(object,
 
   if(stored_subtitle == "\n "){
     if(warn_labs) {
-      message("Your plot has no subtitle, which is weird for a fullslide.\nConsider adding a subtitle using labs(subtitle = 'Text')")
+      message(paste0("Your plot has no subtitle, which is weird for type = ", type, "\nConsider adding a subtitle using labs(subtitle = 'Text')"))
     }
-    stored_subtitle <- ""
+    stored_subtitle <- NULL
   }
 
   if(stored_caption == ""){
@@ -104,7 +104,7 @@ create_fullslide <- function(object,
   top_border_height <- ifelse(type == "blog", blog_border, 0.70)
   header_height <- 1.75
   linegrob_height <- 0.1
-  subtitle_height <- 1.76
+  subtitle_height <- ifelse(is.null(stored_subtitle), 0.3, 1.76)
   bottom_border_height <- ifelse(type == "blog", blog_border, 0.24)
 
   non_plot_height <- sum(top_border_height, header_height, linegrob_height,

--- a/R/create_fullslide.R
+++ b/R/create_fullslide.R
@@ -104,7 +104,7 @@ create_fullslide <- function(object,
   top_border_height <- ifelse(type == "blog", blog_border, 0.70)
   header_height <- 1.75
   linegrob_height <- 0.1
-  subtitle_height <- ifelse(is.null(stored_subtitle), 0.3, 1.76)
+  subtitle_height <- ifelse(is.null(stored_subtitle), 0.21, 1.76)
   bottom_border_height <- ifelse(type == "blog", blog_border, 0.24)
 
   non_plot_height <- sum(top_border_height, header_height, linegrob_height,

--- a/R/wrap_labs.R
+++ b/R/wrap_labs.R
@@ -51,12 +51,12 @@ wrap_labs <- function(object, type){
 
   # add line break to subtitle where necessary
 
-  if(nchar(stored_subtitle) <= char_width_grattan_subtitle &
-     chart_class == "fullslide" &
-     !grepl("\n", stored_subtitle)){
-    stored_subtitle <- paste0(stored_subtitle, "\n ")
-
-  }
+  # if(nchar(stored_subtitle) <= char_width_grattan_subtitle &
+  #    chart_class == "fullslide" &
+  #    !grepl("\n", stored_subtitle)){
+  #   stored_subtitle <- paste0(stored_subtitle, "\n ")
+  #
+  # }
 
   if(nchar(stored_subtitle) > 2 * char_width_grattan_subtitle) {
       # code to figure out the final 2 chunks of text before the title limit

--- a/tests/figs/vdiffr-tests/no-subtitle-plot.svg
+++ b/tests/figs/vdiffr-tests/no-subtitle-plot.svg
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ=='>
+    <rect x='28.24' y='32.29' width='683.12' height='473.57' />
+  </clipPath>
+</defs>
+<rect x='28.24' y='32.29' width='683.12' height='473.57' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<polyline points='28.24,491.66 711.36,491.66 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<polyline points='28.24,400.06 711.36,400.06 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<polyline points='28.24,308.46 711.36,308.46 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<polyline points='28.24,216.86 711.36,216.86 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<polyline points='28.24,125.26 711.36,125.26 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<polyline points='28.24,33.67 711.36,33.67 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='235.07' cy='290.14' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='275.56' cy='290.14' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='187.44' cy='257.17' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='329.55' cy='282.82' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='365.28' cy='332.28' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='368.45' cy='343.27' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='385.92' cy='412.89' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='325.58' cy='227.86' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='319.23' cy='257.17' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='365.28' cy='323.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='365.28' cy='348.77' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='465.31' cy='374.41' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='411.33' cy='357.93' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='419.26' cy='396.40' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='652.68' cy='484.33' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='680.31' cy='484.33' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='667.77' cy='405.56' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='168.38' cy='81.30' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='75.49' cy='117.94' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='110.42' cy='53.82' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='210.46' cy='280.98' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='377.98' cy='390.90' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='364.48' cy='396.40' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='428.79' cy='431.21' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='429.59' cy='323.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='126.30' cy='174.73' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='158.85' cy='198.54' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='59.30' cy='117.94' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='322.40' cy='385.41' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='258.89' cy='313.96' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='385.92' cy='400.06' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<circle cx='260.48' cy='282.82' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44NnwzMi4yOQ==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='497.86' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='406.26' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='314.66' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='223.06' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='131.46' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='39.86' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>35</text></g>
+<polyline points='28.24,505.86 711.36,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='136.62,510.34 136.62,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='295.41,510.34 295.41,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='454.20,510.34 454.20,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='612.98,510.34 612.98,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='131.62' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='290.40' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='449.19' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='607.98' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='360.80' y='546.93' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='18.00px' lengthAdjust='spacingAndGlyphs'>wt</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='19.59' style='font-size: 18.00px; font-weight: bold; fill: #6A737B; font-family: Liberation Sans;' textLength='638.33px' lengthAdjust='spacingAndGlyphs'>Here goes a Grattan title, blah blah lots of words go here extremely orange</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='572.48' style='font-size: 9.99px; font-style: italic; font-family: Liberation Sans;' textLength='143.16px' lengthAdjust='spacingAndGlyphs'>Notes: Blah Source: somewhere</text></g>
+</svg>

--- a/tests/figs/vdiffr-tests/short-subtitle-plot.svg
+++ b/tests/figs/vdiffr-tests/short-subtitle-plot.svg
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw=='>
+    <rect x='28.24' y='61.87' width='683.12' height='443.99' />
+  </clipPath>
+</defs>
+<rect x='28.24' y='61.87' width='683.12' height='443.99' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,492.55 711.36,492.55 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,406.67 711.36,406.67 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,320.79 711.36,320.79 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,234.91 711.36,234.91 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,149.03 711.36,149.03 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='28.24,63.15 711.36,63.15 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='235.07' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='275.56' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='187.44' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='329.55' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='343.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='368.45' cy='353.42' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='385.92' cy='418.69' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='325.58' cy='245.22' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='319.23' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='365.28' cy='358.58' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='465.31' cy='382.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='411.33' cy='367.17' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='419.26' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='652.68' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='680.31' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='667.77' cy='411.82' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='168.38' cy='107.81' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='75.49' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='110.42' cy='82.05' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='210.46' cy='295.03' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='377.98' cy='398.08' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='364.48' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='428.79' cy='435.87' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='429.59' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='126.30' cy='195.41' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='158.85' cy='217.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='59.30' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='322.40' cy='392.93' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='258.89' cy='325.94' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='385.92' cy='406.67' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='260.48' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpMjguMjR8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='498.74' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='412.87' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='326.99' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='241.11' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='155.23' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.14' y='69.35' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>35</text></g>
+<polyline points='28.24,505.86 711.36,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='136.62,510.34 136.62,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='295.41,510.34 295.41,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='454.20,510.34 454.20,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='612.98,510.34 612.98,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='131.62' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='290.40' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='449.19' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='607.98' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='360.80' y='546.93' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='18.00px' lengthAdjust='spacingAndGlyphs'>wt</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='44.68' style='font-size: 18.00px; fill: #6A737B; font-family: Liberation Sans;' textLength='174.11px' lengthAdjust='spacingAndGlyphs'>This is a short subtitle</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='19.59' style='font-size: 18.00px; font-weight: bold; fill: #6A737B; font-family: Liberation Sans;' textLength='638.33px' lengthAdjust='spacingAndGlyphs'>Here goes a Grattan title, blah blah lots of words go here extremely orange</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='28.24' y='572.48' style='font-size: 9.99px; font-style: italic; font-family: Liberation Sans;' textLength='143.16px' lengthAdjust='spacingAndGlyphs'>Notes: Blah Source: somewhere</text></g>
+</svg>

--- a/tests/testthat/test-with-vdiffr.R
+++ b/tests/testthat/test-with-vdiffr.R
@@ -21,6 +21,13 @@ coloured_plot <- base_plot +
   grattan_colour_manual(n = 3) +
   theme_grattan()
 
+# fullslide_plot <- grattantheme:::create_fullslide(normal_plot,
+#                                                   type = "fullslide",
+#                                                   height = NULL,
+#                                                   warn_labs = FALSE) %>%
+#   gridExtra::grid.arrange() %>%
+#   ggplotify::as.ggplot()
+
 test_that("normal plot looks correct", {
 
   vdiffr::expect_doppelganger("normal plot", normal_plot)
@@ -42,14 +49,6 @@ test_that("plot with discrete colours looks correct", {
 
 # test_that("fullslide plot looks correct", {
 #
-#   fullslide_plot <- grattantheme:::create_fullslide(normal_plot,
-#                                                     type = "fullslide",
-#                                                     height = NULL,
-#                                                     warn_labs = FALSE) %>%
-#       gridExtra::grid.arrange() %>%
-#       ggplotify::as.ggplot()
-#
-#
 #   vdiffr::expect_doppelganger("fullslide plot", fullslide_plot)
 # })
-#
+

--- a/tests/testthat/test-with-vdiffr.R
+++ b/tests/testthat/test-with-vdiffr.R
@@ -6,20 +6,29 @@ base_plot <- mtcars %>%
              y = mpg)) +
   geom_point() +
   labs(title = "Here goes a Grattan title, blah blah lots of words go here extremely orange",
-       subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs",
        caption = "Notes: Blah Source: somewhere")
 
 normal_plot <- base_plot +
-  theme_grattan()
+  theme_grattan() +
+  labs(subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs")
 
 border_plot <- base_plot +
   facet_wrap(~cyl) +
-  theme_grattan(panel_borders = TRUE)
+  theme_grattan(panel_borders = TRUE) +
+  labs(subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs")
 
 coloured_plot <- base_plot +
   geom_point(aes(col = factor(cyl))) +
   grattan_colour_manual(n = 3) +
+  theme_grattan() +
+  labs(subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs")
+
+no_subtitle_plot <- base_plot +
   theme_grattan()
+
+short_subtitle_plot <- base_plot +
+  theme_grattan() +
+  labs(subtitle = "This is a short subtitle")
 
 # fullslide_plot <- grattantheme:::create_fullslide(normal_plot,
 #                                                   type = "fullslide",
@@ -43,6 +52,18 @@ test_that("faceted plot with borders looks correct", {
 test_that("plot with discrete colours looks correct", {
 
   vdiffr::expect_doppelganger("coloured plot", coloured_plot)
+
+})
+
+test_that("plot with no subtitle fills the blank space", {
+
+  vdiffr::expect_doppelganger("no subtitle plot", no_subtitle_plot)
+
+})
+
+test_that("plot with short subtitle fills the blank space", {
+
+  vdiffr::expect_doppelganger("short subtitle plot", short_subtitle_plot)
 
 })
 


### PR DESCRIPTION
closes #80 

works for both static and animated `fullslide` (and similar) type charts