### PR TITLE
Add theme_grattan chart_types

### DIFF
--- a/R/grattan_save.R
+++ b/R/grattan_save.R
@@ -103,7 +103,9 @@ grattan_save <- function(filename,
                          ...) {
 
   if(!type %in% c("all", chart_types$type)){
-    stop(paste0("`type` not valid"))
+    warning(paste0("`type` not valid, reverting to 'normal'. ",
+                   "See ?grattan_save for valid types."))
+    type <- "normal"
   }
 
   if(type != "all"){

--- a/R/theme_grattan.R
+++ b/R/theme_grattan.R
@@ -4,15 +4,15 @@
 #' style guide.
 #' @param base_family Font family for text elements. Defaults to "sans",
 #' indistinguishable from Arial.
+#' @param type "normal" by detault. Set to "scatter" for scatter plots.
 #' @param flipped FALSE by default. Set to TRUE if using coord_flip(). If set to
 #' TRUE, the theme will show a vertical axis line, ticks & panel grid, while
-#' hiding the horizontals.
+#' hiding the horizontals. Ignored for type = "scatter".
 #' @param background "white" by default. Set to "orange" or "box" if you're making a chart
 #' to go in a Grattan report box.
 #' @param legend "off" by default. Set to "bottom", "left", "right" or "top" as
 #' desired, or a two element numeric vector such as c(0.9, 0.1).
 #' @param panel_borders `FALSE` by default. Set to `TRUE` to enable a black border around the plotting area.
-#'
 #' @importFrom ggthemes theme_foundation
 #' @import ggrepel
 #' @import ggplot2
@@ -110,104 +110,39 @@
 #' @export
 
 theme_grattan <- function(base_size = 18,
-                           base_family = "sans",
-                           flipped = FALSE,
-                           background = "white",
-                           legend = "none",
-                           panel_borders = FALSE) {
+                          base_family = "sans",
+                          type = "normal",
+                          flipped = FALSE,
+                          background = "white",
+                          legend = "none",
+                          panel_borders = FALSE) {
 
-  ret <-
-    ggthemes::theme_foundation(base_size = base_size, base_family = base_family) +
-    ggplot2::theme(line = ggplot2::element_line(colour = grattantheme::grattan_gridlinegrey,
-                              # style guide says axis line = 0.75 points, need to convert to mm
-                              size = 0.75 / (.pt*72.27/96) ),
-          rect = ggplot2::element_rect(fill = "white",
-                              colour = NA,
-                              linetype = 0),
-          text = ggplot2::element_text(colour = "black", size = base_size),
-          ## Axis
-          axis.line = ggplot2::element_line(size = ggplot2::rel(1),
-                                   colour = "black"),
-          axis.line.y = ggplot2::element_blank(),
-          axis.text = ggplot2::element_text(size = ggplot2::rel(1)),
-          axis.ticks = ggplot2::element_line(colour = "black"),
-          axis.ticks.y = ggplot2::element_blank(),
-          axis.title = ggplot2::element_text(size = ggplot2::rel(1)),
-          # style guide:
-          # "there is no need to label the x-axis unless the units are not obvious"
-          axis.title.x = ggplot2::element_text(),
-          axis.title.y = ggplot2::element_blank(),
-          #axis.ticks.length = unit( -base_size * 0.5, "points"),
-          legend.background = ggplot2::element_rect(),
-          #legend.key = element_rect(linetype = 0),
-          #legend.key.size = unit(1.2, "lines"),
-          legend.key.width = NULL,
-          legend.text = ggplot2::element_text(size = ggplot2::rel(1),
-                                     margin = ggplot2::margin(l = base_size / 4,
-                                                     r = base_size, unit = "pt")),
-          legend.text.align = 0,
-          legend.title.align = NULL,
-          legend.position = legend,
-          legend.direction = "horizontal",
-          legend.box = "vertical",
-          legend.spacing = ggplot2::unit(base_size / 18,"cm"),
-          legend.justification = "center",
-          legend.key.height = ggplot2::unit(1, "line"),
-          legend.margin = ggplot2::margin(t = 0, r = 0, b = 0, l = 0, unit = "cm"),
-          legend.title = ggplot2::element_blank(),
-          panel.border = ggplot2::element_blank(),
-          panel.grid.major = ggplot2::element_line(),
-          panel.grid.major.x = ggplot2::element_blank(),
-          panel.grid.minor = ggplot2::element_blank(),
-          panel.spacing = ggplot2::unit(0.25, "lines"),
-          strip.background = ggplot2::element_rect(),
-          strip.text = ggplot2::element_text(size = ggplot2::rel(1)),
-          plot.background = ggplot2::element_rect(),
-          plot.title = ggplot2::element_text(size = ggplot2::rel(1),
-                                    hjust = 0,
-                                    colour = grattantheme::grattan_grey_title,
-                                    face = "bold"),
-          plot.subtitle = element_text(colour = grattantheme::grattan_grey_title,
-                                       vjust = 1,
-                                       margin = margin(t = 0,
-                                                       r = 0,
-                                                       b = base_size * .75,
-                                                       l = 0,
-                                                       unit = "pt"),
-                                       hjust = 0),
-          plot.caption = element_text(family = base_family,
-                                      size = rel(0.555),
-                                      hjust = 0,
-                                      colour = "black",
-                                      face = "italic",
-                                      margin = ggplot2::margin(t = 15)),
-          plot.margin = unit(c(0.5, 0.6, 0.1, 0.01) , "lines"),
-          complete = TRUE)
-
-  # add panel borders if the user requests them
-
-  if(panel_borders) {
-    ret <- ret +
-      theme(panel.background = element_rect(linetype = 1,
-                                            colour = "black"))
+  if (!type %in% c("normal", "scatter")) {
+    warning(paste0("Note: type should be 'normal' or 'scatter', but you entered '",
+                   type,"'. Reverting to 'normal'"))
+    type <- "normal"
   }
 
 
-  # call a function that modifies various geom defaults
-  grattanify_geom_defaults()
-
-  # reverse when flipped = TRUE
-  if (flipped) {
-    ret <- ret + ggplot2::theme(panel.grid.major.x = ggplot2::element_line(),
-                       panel.grid.major.y = ggplot2::element_blank(),
-                       axis.line.x = ggplot2::element_blank(),
-                       axis.line.y = ggplot2::element_line(),
-                       axis.ticks.y = ggplot2::element_line(),
-                       axis.ticks.x = ggplot2::element_blank())
-  }
-  if (background == "orange" |  background == "box") {
-    ret <- ret + ggplot2::theme(rect = ggplot2::element_rect(fill = grattantheme::grattan_orange_alpha))
+  if (type == "normal") {
+    ret <- theme_grattan_normal(base_size = base_size,
+                                base_family = base_family,
+                                background = background,
+                                legend = legend,
+                                panel_borders = panel_borders,
+                                flipped = flipped)
   }
 
-  ret
+  if (type == "scatter") {
+    ret <- theme_grattan_scatter(base_size = base_size,
+                                 base_family = base_family,
+                                 background = background,
+                                 legend = legend,
+                                 panel_borders = panel_borders)
+  }
+
+  return(ret)
+
 }
+
+

--- a/R/theme_grattan.R
+++ b/R/theme_grattan.R
@@ -123,7 +123,6 @@ theme_grattan <- function(base_size = 18,
     type <- "normal"
   }
 
-
   if (type == "normal") {
     ret <- theme_grattan_normal(base_size = base_size,
                                 base_family = base_family,
@@ -139,6 +138,7 @@ theme_grattan <- function(base_size = 18,
                                  background = background,
                                  legend = legend,
                                  panel_borders = panel_borders)
+    message("Note that the 'flipped' argument is ignored for scatter plots.")
   }
 
   return(ret)

--- a/R/theme_grattan.R
+++ b/R/theme_grattan.R
@@ -4,7 +4,7 @@
 #' style guide.
 #' @param base_family Font family for text elements. Defaults to "sans",
 #' indistinguishable from Arial.
-#' @param type "normal" by detault. Set to "scatter" for scatter plots.
+#' @param chart_type "normal" by detault. Set to "scatter" for scatter plots.
 #' @param flipped FALSE by default. Set to TRUE if using coord_flip(). If set to
 #' TRUE, the theme will show a vertical axis line, ticks & panel grid, while
 #' hiding the horizontals. Ignored for type = "scatter".
@@ -111,19 +111,19 @@
 
 theme_grattan <- function(base_size = 18,
                           base_family = "sans",
-                          type = "normal",
+                          chart_type = "normal",
                           flipped = FALSE,
                           background = "white",
                           legend = "none",
                           panel_borders = FALSE) {
 
-  if (!type %in% c("normal", "scatter")) {
-    warning(paste0("Note: type should be 'normal' or 'scatter', but you entered '",
-                   type,"'. Reverting to 'normal'"))
-    type <- "normal"
+  if (!chart_type %in% c("normal", "scatter")) {
+    warning(paste0("Note: chart_type should be 'normal' or 'scatter', but you entered '",
+                   chart_type,"'. Reverting to 'normal'"))
+    chart_type <- "normal"
   }
 
-  if (type == "normal") {
+  if (chart_type == "normal") {
     ret <- theme_grattan_normal(base_size = base_size,
                                 base_family = base_family,
                                 background = background,
@@ -132,13 +132,13 @@ theme_grattan <- function(base_size = 18,
                                 flipped = flipped)
   }
 
-  if (type == "scatter") {
+  if (chart_type == "scatter") {
     ret <- theme_grattan_scatter(base_size = base_size,
                                  base_family = base_family,
                                  background = background,
                                  legend = legend,
                                  panel_borders = panel_borders)
-    message("Note that the 'flipped' argument is ignored for scatter plots.")
+    if (flipped) message("Note that the 'flipped' argument is ignored for scatter plots.")
   }
 
   return(ret)

--- a/R/theme_grattan.R
+++ b/R/theme_grattan.R
@@ -141,6 +141,10 @@ theme_grattan <- function(base_size = 18,
     if (flipped) message("Note that the 'flipped' argument is ignored for scatter plots.")
   }
 
+  # Call a function that modifies various geom defaults
+  grattanify_geom_defaults()
+
+  # Return
   return(ret)
 
 }

--- a/R/theme_grattan_base.R
+++ b/R/theme_grattan_base.R
@@ -1,0 +1,103 @@
+# This function is called by `theme_grattan` but is not exported.
+
+theme_grattan_base <- function(base_size = 18,
+                               base_family = "sans",
+                               background = "white",
+                               legend = "none",
+                               panel_borders = FALSE) {
+
+  ret <-
+    ggthemes::theme_foundation(base_size = base_size, base_family = base_family) +
+    ggplot2::theme(line = ggplot2::element_line(colour = grattantheme::grattan_gridlinegrey,
+                                                # style guide says axis line = 0.75 points, need to convert to mm
+                                                size = 0.75 / (.pt*72.27/96) ),
+                   rect = ggplot2::element_rect(fill = "white",
+                                                colour = NA,
+                                                linetype = 0),
+                   text = ggplot2::element_text(colour = "black", size = base_size),
+                   ## Axis
+                   axis.line = ggplot2::element_line(size = ggplot2::rel(1),
+                                                     colour = "black"),
+                   # moved to theme_grattan()
+                   # axis.line.y = ggplot2::element_blank(),
+                   axis.text = ggplot2::element_text(size = ggplot2::rel(1)),
+                   axis.ticks = ggplot2::element_line(colour = "black"),
+                   # moved to theme_grattan()
+                   # axis.ticks.y = ggplot2::element_blank(),
+                   axis.title = ggplot2::element_text(size = ggplot2::rel(1)),
+                   # style guide:
+                   # "there is no need to label the x-axis unless the units are not obvious"
+                   axis.title.x = ggplot2::element_text(),
+                   # moved to theme_grattan()
+                   # axis.title.y = ggplot2::element_blank(),
+                   #axis.ticks.length = unit( -base_size * 0.5, "points"),
+                   legend.background = ggplot2::element_rect(),
+                   #legend.key = element_rect(linetype = 0),
+                   #legend.key.size = unit(1.2, "lines"),
+                   legend.key.width = NULL,
+                   legend.text = ggplot2::element_text(size = ggplot2::rel(1),
+                                                       margin = ggplot2::margin(l = base_size / 4,
+                                                                                r = base_size, unit = "pt")),
+                   legend.text.align = 0,
+                   legend.title.align = NULL,
+                   legend.position = legend,
+                   legend.direction = "horizontal",
+                   legend.box = "vertical",
+                   legend.spacing = ggplot2::unit(base_size / 18,"cm"),
+                   legend.justification = "center",
+                   legend.key.height = ggplot2::unit(1, "line"),
+                   legend.margin = ggplot2::margin(t = 0, r = 0, b = 0, l = 0, unit = "cm"),
+                   legend.title = ggplot2::element_blank(),
+                   panel.border = ggplot2::element_blank(),
+                   panel.grid.major = ggplot2::element_line(),
+                   # moved to theme_grattan()
+                   # panel.grid.major.x = ggplot2::element_blank(),
+                   panel.grid.minor = ggplot2::element_blank(),
+                   panel.spacing = ggplot2::unit(0.25, "lines"),
+                   strip.background = ggplot2::element_rect(),
+                   strip.text = ggplot2::element_text(size = ggplot2::rel(1)),
+                   plot.background = ggplot2::element_rect(),
+                   plot.title = ggplot2::element_text(size = ggplot2::rel(1),
+                                                      hjust = 0,
+                                                      colour = grattantheme::grattan_grey_title,
+                                                      face = "bold"),
+                   plot.subtitle = element_text(colour = grattantheme::grattan_grey_title,
+                                                vjust = 1,
+                                                margin = margin(t = 0,
+                                                                r = 0,
+                                                                b = base_size * .75,
+                                                                l = 0,
+                                                                unit = "pt"),
+                                                hjust = 0),
+                   plot.caption = element_text(family = base_family,
+                                               size = rel(0.555),
+                                               hjust = 0,
+                                               colour = "black",
+                                               face = "italic",
+                                               margin = ggplot2::margin(t = 15)),
+                   plot.margin = unit(c(0.5, 0.6, 0.1, 0.01) , "lines"),
+                   complete = TRUE)
+
+  # add panel borders if the user requests them
+  if(panel_borders) {
+    ret <- ret +
+      theme(panel.background = element_rect(linetype = 1,
+                                            colour = "black"))
+  }
+
+
+  # call a function that modifies various geom defaults
+  grattanify_geom_defaults()
+
+
+  if (background == "orange" |  background == "box") {
+    ret <- ret + ggplot2::theme(rect = ggplot2::element_rect(fill = grattantheme::grattan_orange_alpha))
+  }
+
+  ret
+
+}
+
+
+
+

--- a/R/theme_grattan_base.R
+++ b/R/theme_grattan_base.R
@@ -86,10 +86,6 @@ theme_grattan_base <- function(base_size = 18,
   }
 
 
-  # call a function that modifies various geom defaults
-  grattanify_geom_defaults()
-
-
   if (background == "orange" |  background == "box") {
     ret <- ret + ggplot2::theme(rect = ggplot2::element_rect(fill = grattantheme::grattan_orange_alpha))
   }

--- a/R/theme_grattan_normal.R
+++ b/R/theme_grattan_normal.R
@@ -1,0 +1,35 @@
+# This function is called by `theme_grattan` but is not exported.
+
+theme_grattan_normal <- function(base_size = 18,
+                                 base_family = "sans",
+                                 flipped = FALSE,
+                                 background = "white",
+                                 legend = "none",
+                                 panel_borders = FALSE) {
+
+ret <- theme_grattan_base(base_size = base_size,
+                          base_family = base_family,
+                          background = background,
+                          legend = legend,
+                          panel_borders = panel_borders)
+
+
+ret <- ret +
+  ggplot2::theme(axis.line.y = ggplot2::element_blank(),
+                 axis.ticks.y = ggplot2::element_blank(),
+                 axis.title.y = ggplot2::element_blank(),
+                 panel.grid.major.x = ggplot2::element_blank())
+
+# reverse when flipped = TRUE; only if type = 'normal'
+if (flipped) {
+  ret <- ret + ggplot2::theme(panel.grid.major.x = ggplot2::element_line(),
+                              panel.grid.major.y = ggplot2::element_blank(),
+                              axis.line.x = ggplot2::element_blank(),
+                              axis.line.y = ggplot2::element_line(),
+                              axis.ticks.y = ggplot2::element_line(),
+                              axis.ticks.x = ggplot2::element_blank())
+}
+
+ret
+
+}

--- a/R/theme_grattan_scatter.R
+++ b/R/theme_grattan_scatter.R
@@ -1,0 +1,17 @@
+# This function is called by `theme_grattan` but is not exported.
+
+theme_grattan_scatter <- function(base_size = 18,
+                                  base_family = "sans",
+                                  background = "white",
+                                  legend = "none",
+                                  panel_borders = FALSE) {
+
+  ret <- theme_grattan_base(base_size = base_size,
+                            base_family = base_family,
+                            background = background,
+                            legend = legend,
+                            panel_borders = panel_borders)
+
+  ret
+
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,7 @@ Once grattantheme is installed, you can load it the same way you normally load a
 
 See the [grattantheme vignette](https://github.com/MattCowgill/grattantheme/blob/master/vignettes/using_grattantheme.pdf) for a more complete guide.
 
-Use `theme_grattan()` to format your ggplot2 charts in a style consistent with the Grattan style guide, including elements such as gridline colours and line width, font size, etc.
+Use `theme_grattan()` to format your ggplot2 charts in a style consistent with the Grattan style guide, including elements such as gridline colours and line width, font size, etc. For scatter plots,  `theme_grattan(chart_type = "scatter")` provides a black y-axis. 
 
 Use `grattan_colour_manual(n)` or `grattan_fill_manual(n)` to format the `n` coloured elements of your `ggplot2` plot. These functions will choose appropriately-spaced Grattan colours, ordered from either light to dark or the reverse. 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ for a more complete guide.
 
 Use `theme_grattan()` to format your ggplot2 charts in a style
 consistent with the Grattan style guide, including elements such as
-gridline colours and line width, font size, etc.
+gridline colours and line width, font size, etc. For scatter plots,
+`theme_grattan(chart_type = "scatter")` provides a black y-axis.
 
 Use `grattan_colour_manual(n)` or `grattan_fill_manual(n)` to format the
 `n` coloured elements of your `ggplot2` plot. These functions will

--- a/man/theme_grattan.Rd
+++ b/man/theme_grattan.Rd
@@ -4,9 +4,9 @@
 \alias{theme_grattan}
 \title{Create a ggplot2 theme consistent with the Grattan style guide.}
 \usage{
-theme_grattan(base_size = 18, base_family = "sans", type = "normal",
-  flipped = FALSE, background = "white", legend = "none",
-  panel_borders = FALSE)
+theme_grattan(base_size = 18, base_family = "sans",
+  chart_type = "normal", flipped = FALSE, background = "white",
+  legend = "none", panel_borders = FALSE)
 }
 \arguments{
 \item{base_size}{Size for text elements. Defaults to 18, as per the Grattan
@@ -15,7 +15,7 @@ style guide.}
 \item{base_family}{Font family for text elements. Defaults to "sans",
 indistinguishable from Arial.}
 
-\item{type}{"normal" by detault. Set to "scatter" for scatter plots.}
+\item{chart_type}{"normal" by detault. Set to "scatter" for scatter plots.}
 
 \item{flipped}{FALSE by default. Set to TRUE if using coord_flip(). If set to
 TRUE, the theme will show a vertical axis line, ticks & panel grid, while

--- a/man/theme_grattan.Rd
+++ b/man/theme_grattan.Rd
@@ -4,8 +4,9 @@
 \alias{theme_grattan}
 \title{Create a ggplot2 theme consistent with the Grattan style guide.}
 \usage{
-theme_grattan(base_size = 18, base_family = "sans", flipped = FALSE,
-  background = "white", legend = "none", panel_borders = FALSE)
+theme_grattan(base_size = 18, base_family = "sans", type = "normal",
+  flipped = FALSE, background = "white", legend = "none",
+  panel_borders = FALSE)
 }
 \arguments{
 \item{base_size}{Size for text elements. Defaults to 18, as per the Grattan
@@ -14,9 +15,11 @@ style guide.}
 \item{base_family}{Font family for text elements. Defaults to "sans",
 indistinguishable from Arial.}
 
+\item{type}{"normal" by detault. Set to "scatter" for scatter plots.}
+
 \item{flipped}{FALSE by default. Set to TRUE if using coord_flip(). If set to
 TRUE, the theme will show a vertical axis line, ticks & panel grid, while
-hiding the horizontals.}
+hiding the horizontals. Ignored for type = "scatter".}
 
 \item{background}{"white" by default. Set to "orange" or "box" if you're making a chart
 to go in a Grattan report box.}

--- a/tests/figs/vdiffr-tests/scatter-plot.svg
+++ b/tests/figs/vdiffr-tests/scatter-plot.svg
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw=='>
+    <rect x='48.85' y='61.87' width='662.51' height='443.99' />
+  </clipPath>
+</defs>
+<rect x='48.85' y='61.87' width='662.51' height='443.99' style='stroke-width: 1.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='48.85,492.55 711.36,492.55 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='48.85,406.67 711.36,406.67 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='48.85,320.79 711.36,320.79 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='48.85,234.91 711.36,234.91 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='48.85,149.03 711.36,149.03 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='48.85,63.15 711.36,63.15 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='153.96,505.86 153.96,61.87 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='307.96,505.86 307.96,61.87 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='461.96,505.86 461.96,61.87 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<polyline points='615.95,505.86 615.95,61.87 ' style='stroke-width: 0.75; stroke: #C3C7CB; stroke-linecap: butt;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='249.44' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='288.71' cy='303.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='203.24' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='341.07' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='375.72' cy='343.12' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='378.80' cy='353.42' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='395.74' cy='418.69' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='337.22' cy='245.22' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='331.06' cy='272.70' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='375.72' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='375.72' cy='358.58' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='472.74' cy='382.62' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='420.38' cy='367.17' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='428.08' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='654.45' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='681.25' cy='485.68' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='669.08' cy='411.82' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='184.76' cy='107.81' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='94.67' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='128.55' cy='82.05' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='225.57' cy='295.03' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='388.04' cy='398.08' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='374.95' cy='403.23' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='437.32' cy='435.87' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='438.09' cy='334.53' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='143.95' cy='195.41' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='175.52' cy='217.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='78.97' cy='142.16' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='334.14' cy='392.93' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='272.54' cy='325.94' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='395.74' cy='406.67' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<circle cx='274.08' cy='296.74' r='2.60pt' style='stroke-width: 0.71; stroke: #F68B33; fill: #F68B33;' clip-path='url(#cpNDguODV8NzExLjM2fDUwNS44Nnw2MS44Nw==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='48.85,505.86 48.85,61.87 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='20.75' y='498.74' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='20.75' y='412.87' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='20.75' y='326.99' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='20.75' y='241.11' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='20.75' y='155.23' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='20.75' y='69.35' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='20.03px' lengthAdjust='spacingAndGlyphs'>35</text></g>
+<polyline points='44.37,492.55 48.85,492.55 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.37,406.67 48.85,406.67 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.37,320.79 48.85,320.79 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.37,234.91 48.85,234.91 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.37,149.03 48.85,149.03 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.37,63.15 48.85,63.15 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='48.85,505.86 711.36,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='153.96,510.34 153.96,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='307.96,510.34 307.96,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='461.96,510.34 461.96,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='615.95,510.34 615.95,505.86 ' style='stroke-width: 0.75; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='148.96' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='302.95' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='456.95' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='610.94' y='526.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='10.02px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='371.11' y='546.93' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='18.00px' lengthAdjust='spacingAndGlyphs'>wt</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(12.53,301.38) rotate(-90)' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='35.03px' lengthAdjust='spacingAndGlyphs'>mpg</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='48.85' y='44.68' style='font-size: 18.00px; fill: #6A737B; font-family: Liberation Sans;' textLength='682.61px' lengthAdjust='spacingAndGlyphs'>Either put units here or jam an elaborate thing here that describes both axes, whatevs</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='48.85' y='19.59' style='font-size: 18.00px; font-weight: bold; fill: #6A737B; font-family: Liberation Sans;' textLength='638.33px' lengthAdjust='spacingAndGlyphs'>Here goes a Grattan title, blah blah lots of words go here extremely orange</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='48.85' y='572.48' style='font-size: 9.99px; font-style: italic; font-family: Liberation Sans;' textLength='143.16px' lengthAdjust='spacingAndGlyphs'>Notes: Blah Source: somewhere</text></g>
+</svg>

--- a/tests/testthat/test-grattan_save.R
+++ b/tests/testthat/test-grattan_save.R
@@ -106,3 +106,13 @@ test_that("grattan_save() height behaviour works as expected with fullslide char
   unlink("test_plot_fullslide_manual_height.png")
 
 })
+
+
+test_that("grattan_save() sends the right messages",{
+  expect_warning(
+  grattan_save(filename = "test_plot_normal_default_height.png",
+               object = test_plot,
+               type = "nahhhh mate")
+  )
+
+})

--- a/tests/testthat/test-theme_grattan.R
+++ b/tests/testthat/test-theme_grattan.R
@@ -6,6 +6,8 @@ base_plot <- ggplot(mtcars, aes(x = mpg, y = hp)) +
 
 p <- base_plot + theme_grattan()
 
+p_scatter <- base_plot + theme_grattan(chart_type = "scatter")
+
 test_that("theme_grattan() is a theme object", {
   expect_is(theme_grattan(), "theme")
 })
@@ -37,6 +39,12 @@ test_that("theme_grattan() arguments work",{
   p_legend <- base_plot + theme_grattan(legend = "top")
 
   expect_equal(p_legend$theme$legend.position, "top")
+
+  # Normal plot:
+  expect_equal(class(p$theme$axis.line.y)[1], "element_blank")
+
+  # Scatter plot:
+  expect_null(p_scatter$theme$axis.line.y)
 
 })
 

--- a/tests/testthat/test-theme_grattan.R
+++ b/tests/testthat/test-theme_grattan.R
@@ -48,3 +48,12 @@ test_that("theme_grattan() arguments work",{
 
 })
 
+
+test_that("theme_grattan() sends the right messages",{
+  expect_message(base_plot +
+                  theme_grattan(chart_type = "scatter", flipped = TRUE))
+
+  expect_warning(base_plot +
+                   theme_grattan(chart_type = "nah mate"))
+
+})

--- a/tests/testthat/test-with-vdiffr.R
+++ b/tests/testthat/test-with-vdiffr.R
@@ -12,6 +12,11 @@ normal_plot <- base_plot +
   theme_grattan() +
   labs(subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs")
 
+scatter_plot <- base_plot +
+  theme_grattan(chart_type = "scatter") +
+  labs(subtitle = "Either put units here or jam an elaborate thing here that describes both axes, whatevs")
+
+
 border_plot <- base_plot +
   facet_wrap(~cyl) +
   theme_grattan(panel_borders = TRUE) +
@@ -42,6 +47,15 @@ test_that("normal plot looks correct", {
   vdiffr::expect_doppelganger("normal plot", normal_plot)
 
 })
+
+test_that("scatter plot looks correct", {
+
+  vdiffr::expect_doppelganger("scatter plot", scatter_plot)
+
+})
+
+
+
 
 test_that("faceted plot with borders looks correct", {
 


### PR DESCRIPTION
`theme_grattan_base` defines common theme elements.  
`theme_grattan_normal` defines additional theme elements for a normal plot.
`theme_grattan_scatter` defines additional theme elements for a scatter plot.

Either `theme_grattan_normal` or `theme_grattan_scatter` are called using the `chart_type` option in `theme_grattan`:  `theme_grattan(chart_type = "normal|scatter")`

@MattCowgill lmk what you think of the structure. V open to alternatives. 